### PR TITLE
Added ability to configure Nextcloud apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,34 @@ The parameter `status` specifies whether the app should be `disabled` or `enable
 
 Both parameters can be ommitted and replaced with an empty string `''` or an empty hash `{}`. In this case the default values will be used (present/enabled).
 
+### Configuring Apps
+
+Nextcloud apps can be configured using the `$app_config` parameter:
+
+```puppet
+class { 'nextcloud':
+  apps => {
+    document_community => {
+      ensure => present,
+      status => enabled,
+    },
+    onlyoffice => {
+      ensure => present,
+      status => enabled,
+    },
+  },
+  app_config => {
+    onlyoffice => {
+      DocumentServerUrl => "https://${$facts['fqdn']}/index.php/apps/documentserver_community/",
+      verify_peer_off: 'true',
+    },
+  },
+}
+```
+
+The app name should be the hey in the hash and any configuration parameters for that app
+should be key/value pairs within.
+
 ### Performing Updates
 
 The module will automatically perform updates of Nextcloud when the value of `$version` is changed. Nextcloud's native upgrade command will also be utilized, but depending on the size of the installation, it may be required to increase the value of `$command_timeout`. The use of the native upgrade command may be disabled by setting `$update_enabled` to `false`, which will allow to perform this step manually at any time. Note that this does NOT prevent the automatic update, it will only skip the native upgrade command. To completely disable all updates, the parameter `$update_enabled` must be set to `none`.

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -2,6 +2,7 @@
 nextcloud::admin_password: ~
 nextcloud::admin_user: 'admin'
 nextcloud::apps: {}
+nextcloud::app_config: {}
 nextcloud::command_timeout: 7200
 nextcloud::config:
   trusted_domains:

--- a/manifests/app_config.pp
+++ b/manifests/app_config.pp
@@ -1,0 +1,43 @@
+# @summary Set configuration options for Nextcloud apps
+# @api private
+class nextcloud::app_config {
+  assert_private()
+
+  $nextcloud::app_config.each | $_app_name, $_app_configs | {
+    $_app_configs.each | $_config_key, $_config_value | {
+      case $_config_value {
+        String, Boolean, Integer: {
+          nextcloud::config_command { "${_app_name} ${_config_key}":
+            section      => 'app',
+            value        => $_config_value,
+            verify_key   => "${_app_name} ${_config_key}",
+            verify_value => $_config_value,
+          }
+        }
+        Array: {
+          $_config_value.each | $_index, $_config_array_value | {
+            nextcloud::config_command { "${_app_name} ${_config_key} ${_index}":
+              section      => 'app',
+              value        => $_config_array_value,
+              verify_key   => "${_app_name} ${_config_key}",
+              verify_value => $_config_array_value,
+            }
+          }
+        }
+        Hash: {
+          $_config_value.each | $_config_hash_key, $_config_hash_value | {
+            nextcloud::config_command { "${_app_name} ${_config_key} \'${_config_hash_key}\'":
+              section      => 'app',
+              value        => $_config_hash_value,
+              verify_key   => "${_app_name} ${_config_key} ${_config_hash_key}",
+              verify_value => $_config_hash_value,
+            }
+          }
+        }
+        default: {
+          fail("Unexpected data type in config for key ${_config_key}")
+        }
+      }
+    }
+  }
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,7 @@ class nextcloud::config {
     case $_config_value {
       String, Boolean, Integer: {
         nextcloud::config_command { $_config_key:
+          section      => 'system',
           value        => $_config_value,
           verify_key   => $_config_key,
           verify_value => $_config_value,
@@ -15,6 +16,7 @@ class nextcloud::config {
       Array: {
         $_config_value.each | $_index, $_config_array_value | {
           nextcloud::config_command { "${_config_key} ${_index}":
+            section      => 'system',
             value        => $_config_array_value,
             verify_key   => $_config_key,
             verify_value => $_config_array_value,
@@ -24,6 +26,7 @@ class nextcloud::config {
       Hash: {
         $_config_value.each | $_config_hash_key, $_config_hash_value | {
           nextcloud::config_command { "${_config_key} \'${_config_hash_key}\'":
+            section      => 'system',
             value        => $_config_hash_value,
             verify_key   => "${_config_key} ${_config_hash_key}",
             verify_value => $_config_hash_value,

--- a/manifests/config_command.pp
+++ b/manifests/config_command.pp
@@ -18,26 +18,27 @@ define nextcloud::config_command (
   Variant[Boolean, Integer, String] $verify_key,
   Variant[Boolean, Integer, String] $verify_value,
   Variant[Boolean, Integer, String] $key = $title,
+  Enum['app', 'system']             $section = 'system',
 ){
   # Check if the configuration key should be removed.
   $_key = split($key, /:/)
   case $_key[0] {
     'DELETE': {
       $cfg_key = $_key[1]
-      $_occ_cmd = 'config:system:delete'
+      $_occ_cmd = "config:${section}:delete"
       $_occ_args = $cfg_key
       $unless_cmd = join([
-        "php occ config:system:get ${cfg_key}",
+        "php occ config:${section}:get ${cfg_key}",
         # Modify the exit code to work with Exec's "unless".
         '; _exit=$?; test $_exit -gt 0'
       ], ' ')
     }
     default: {
       $cfg_key = $key
-      $_occ_cmd = 'config:system:set'
+      $_occ_cmd = "config:${section}:set"
       $_occ_args = "${cfg_key} --value=\'${value}\'"
       $unless_cmd = join([
-        'php occ config:system:get',
+        "php occ config:${section}:get",
         $verify_key,
         '| grep -qF',
         "\'${verify_value}\'",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,16 @@
 # @param apps
 #   Specifies a list of Nextcloud apps and their desired state.
 #
+# @param app_config
+#   A hash containing configuration options for Nextcloud apps.
+#   The hash should be in the format:
+#   {
+#     'my_app_name' => {
+#       'setting1' => 'xyz123',
+#       'setting2' => 'blah',
+#     },
+#   }
+#
 # @param command_timeout
 #   Specifies the time to wait for install/update/maintenance commands
 #   to complete. Keep in mind that several commands may take a few hours
@@ -101,6 +111,7 @@
 #
 class nextcloud (
   Hash $apps,
+  Hash $app_config,
   String $admin_password,
   String $admin_user,
   Integer $command_timeout,
@@ -162,14 +173,14 @@ class nextcloud (
 
   # NOTE: All commands should use a simple lock mechanism to prevent concurrent
   # execution when multiple servers are used:
-  # 
+  #
   # - create a lock file as part of the command execution
   # - do not run the Exec if the lock file can be found
   # - remove the lock file as part of the command execution
-  # 
+  #
   # The lock file should be created in Nextcloud's data directory, because
   # this is most likely shared between all servers.
-  # 
+  #
   # Ensure that the lock file is removed, even if the command fails. This way
   # a failed command can be retried.
 
@@ -178,5 +189,6 @@ class nextcloud (
   -> class { 'nextcloud::update': }
   -> class { 'nextcloud::apps': }
   -> class { 'nextcloud::config': }
+  -> class { 'nextcloud::app_config': }
   -> class { 'nextcloud::cron': }
 }

--- a/spec/classes/nextcloud_spec.rb
+++ b/spec/classes/nextcloud_spec.rb
@@ -21,6 +21,7 @@ describe 'nextcloud' do
         it { is_expected.to contain_class('nextcloud::update') }
         it { is_expected.to contain_class('nextcloud::apps') }
         it { is_expected.to contain_class('nextcloud::config') }
+        it { is_expected.to contain_class('nextcloud::app_config') }
         it { is_expected.to contain_class('nextcloud::cron') }
 
         it { is_expected.to contain_file('/opt/nextcloud-data').with_ensure('directory') }


### PR DESCRIPTION
Previously the `config_command` only supported `system` configs, example:
```
php occ config:system:set <key> <value>
```

Apps in Nextcloud can be configured using a similar command:
```
php occ config:app:set <app> <key> <value>
```

This PR adds the ability to configure apps by augmenting the existing `config_command` class and adding a new `app_config` hash to the main nextcloud class.